### PR TITLE
feat: Implement DTOs, Entities, and Swagger Documentation for ApiKeySubscription

### DIFF
--- a/src/libs/apiKeySubs/dtos/create-apy-key-subs.dto.ts
+++ b/src/libs/apiKeySubs/dtos/create-apy-key-subs.dto.ts
@@ -1,58 +1,106 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, IsOptional, IsInt, IsBoolean, IsDate, IsISO8601 } from 'class-validator';
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsInt,
+  IsBoolean,
+  IsISO8601,
+} from 'class-validator';
 
 export class CreateApiKeySubscriptionDto {
-  @ApiProperty({ description: 'Type of the API key subscription', example: 'basic' })
+  @ApiProperty({
+    description: 'Type of the API key subscription',
+    example: 'basic',
+  })
   @IsString()
   @IsNotEmpty()
   type: string;
 
-  @ApiProperty({ description: 'API key for the subscription', example: 'abc123' })
+  @ApiProperty({
+    description: 'API key for the subscription',
+    example: 'abc123',
+  })
   @IsString()
   @IsNotEmpty()
   apiKey: string;
 
-  @ApiProperty({ description: 'Usage count of the API key subscription', example: 0, required: false })
+  @ApiProperty({
+    description: 'Usage count of the API key subscription',
+    example: 0,
+    required: false,
+  })
   @IsInt()
   @IsOptional()
   usageCount?: number = 0;
 
-  @ApiProperty({ description: 'Usage limit for the API key subscription', example: 100 })
+  @ApiProperty({
+    description: 'Usage limit for the API key subscription',
+    example: 100,
+  })
   @IsInt()
   @IsNotEmpty()
   limit: number;
 
-  @ApiProperty({ description: 'Status of the API key subscription', example: true, required: false })
+  @ApiProperty({
+    description: 'Status of the API key subscription',
+    example: true,
+    required: false,
+  })
   @IsBoolean()
   @IsOptional()
   isActive?: boolean = true;
 
-  @ApiProperty({ description: 'Creation date of the subscription', example: '2023-07-11T00:00:00.000Z', required: false })
+  @ApiProperty({
+    description: 'Creation date of the subscription',
+    example: '2023-07-11T00:00:00.000Z',
+    required: false,
+  })
   @IsISO8601()
   @IsOptional()
   createdAt?: Date | null = null;
 
-  @ApiProperty({ description: 'User who created the subscription', example: 'user1', required: false })
+  @ApiProperty({
+    description: 'User who created the subscription',
+    example: 'user1',
+    required: false,
+  })
   @IsString()
   @IsOptional()
   createBy?: string;
 
-  @ApiProperty({ description: 'Last updated date of the subscription', example: '2023-07-12T00:00:00.000Z', required: false })
+  @ApiProperty({
+    description: 'Last updated date of the subscription',
+    example: '2023-07-12T00:00:00.000Z',
+    required: false,
+  })
   @IsISO8601()
   @IsOptional()
   updatedAt?: Date | null = null;
 
-  @ApiProperty({ description: 'User who last updated the subscription', example: 'user2', required: false })
+  @ApiProperty({
+    description: 'User who last updated the subscription',
+    example: 'user2',
+    required: false,
+  })
   @IsString()
   @IsOptional()
   updateBy?: string;
 
-  @ApiProperty({ description: 'Deletion date of the subscription', example: '2023-07-13T00:00:00.000Z', required: false })
+  @ApiProperty({
+    description: 'Deletion date of the subscription',
+    example: '2023-07-13T00:00:00.000Z',
+    required: false,
+  })
   @IsISO8601()
   @IsOptional()
   deletedAt?: Date | null = null;
 
-  @ApiProperty({ description: 'User who deleted the subscription', example: 'user3', required: false })
+  @ApiProperty({
+    description: 'User who deleted the subscription',
+    example: 'user3',
+    required: false,
+  })
   @IsString()
   @IsOptional()
   deleteBy?: string;

--- a/src/libs/apiKeySubs/dtos/create-apy-key-subs.dto.ts
+++ b/src/libs/apiKeySubs/dtos/create-apy-key-subs.dto.ts
@@ -1,0 +1,59 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsOptional, IsInt, IsBoolean, IsDate, IsISO8601 } from 'class-validator';
+
+export class CreateApiKeySubscriptionDto {
+  @ApiProperty({ description: 'Type of the API key subscription', example: 'basic' })
+  @IsString()
+  @IsNotEmpty()
+  type: string;
+
+  @ApiProperty({ description: 'API key for the subscription', example: 'abc123' })
+  @IsString()
+  @IsNotEmpty()
+  apiKey: string;
+
+  @ApiProperty({ description: 'Usage count of the API key subscription', example: 0, required: false })
+  @IsInt()
+  @IsOptional()
+  usageCount?: number = 0;
+
+  @ApiProperty({ description: 'Usage limit for the API key subscription', example: 100 })
+  @IsInt()
+  @IsNotEmpty()
+  limit: number;
+
+  @ApiProperty({ description: 'Status of the API key subscription', example: true, required: false })
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean = true;
+
+  @ApiProperty({ description: 'Creation date of the subscription', example: '2023-07-11T00:00:00.000Z', required: false })
+  @IsISO8601()
+  @IsOptional()
+  createdAt?: Date | null = null;
+
+  @ApiProperty({ description: 'User who created the subscription', example: 'user1', required: false })
+  @IsString()
+  @IsOptional()
+  createBy?: string;
+
+  @ApiProperty({ description: 'Last updated date of the subscription', example: '2023-07-12T00:00:00.000Z', required: false })
+  @IsISO8601()
+  @IsOptional()
+  updatedAt?: Date | null = null;
+
+  @ApiProperty({ description: 'User who last updated the subscription', example: 'user2', required: false })
+  @IsString()
+  @IsOptional()
+  updateBy?: string;
+
+  @ApiProperty({ description: 'Deletion date of the subscription', example: '2023-07-13T00:00:00.000Z', required: false })
+  @IsISO8601()
+  @IsOptional()
+  deletedAt?: Date | null = null;
+
+  @ApiProperty({ description: 'User who deleted the subscription', example: 'user3', required: false })
+  @IsString()
+  @IsOptional()
+  deleteBy?: string;
+}

--- a/src/libs/apiKeySubs/dtos/update-apy-key-subs.dto.ts
+++ b/src/libs/apiKeySubs/dtos/update-apy-key-subs.dto.ts
@@ -1,61 +1,112 @@
 import { ApiProperty, PartialType } from '@nestjs/swagger';
-import { IsString, IsOptional, IsInt, IsBoolean, IsDate, IsISO8601 } from 'class-validator';
-import { CreateApiKeySubscriptionDto } from './create-apy-key-subs.dto'
+import {
+  IsString,
+  IsOptional,
+  IsInt,
+  IsBoolean,
+  IsISO8601,
+} from 'class-validator';
+import { CreateApiKeySubscriptionDto } from './create-apy-key-subs.dto';
 
-export class UpdateApiKeySubscriptionDto extends PartialType(CreateApiKeySubscriptionDto) {
-  @ApiProperty({ description: 'Type of the API key subscription', example: 'basic', required: false })
+export class UpdateApiKeySubscriptionDto extends PartialType(
+  CreateApiKeySubscriptionDto,
+) {
+  @ApiProperty({
+    description: 'Type of the API key subscription',
+    example: 'basic',
+    required: false,
+  })
   @IsString()
   @IsOptional()
   type?: string;
 
-  @ApiProperty({ description: 'API key for the subscription', example: 'abc123', required: false })
+  @ApiProperty({
+    description: 'API key for the subscription',
+    example: 'abc123',
+    required: false,
+  })
   @IsString()
   @IsOptional()
   apiKey?: string;
 
-  @ApiProperty({ description: 'Usage count of the API key subscription', example: 0, required: false })
+  @ApiProperty({
+    description: 'Usage count of the API key subscription',
+    example: 0,
+    required: false,
+  })
   @IsInt()
   @IsOptional()
   usageCount?: number;
 
-  @ApiProperty({ description: 'Usage limit for the API key subscription', example: 100, required: false })
+  @ApiProperty({
+    description: 'Usage limit for the API key subscription',
+    example: 100,
+    required: false,
+  })
   @IsInt()
   @IsOptional()
   limit?: number;
 
-  @ApiProperty({ description: 'Status of the API key subscription', example: true, required: false })
+  @ApiProperty({
+    description: 'Status of the API key subscription',
+    example: true,
+    required: false,
+  })
   @IsBoolean()
   @IsOptional()
   isActive?: boolean;
 
-  @ApiProperty({ description: 'Creation date of the subscription', example: '2023-07-11T00:00:00.000Z', required: false })
+  @ApiProperty({
+    description: 'Creation date of the subscription',
+    example: '2023-07-11T00:00:00.000Z',
+    required: false,
+  })
   @IsISO8601()
   @IsOptional()
   createdAt?: Date | null;
 
-  @ApiProperty({ description: 'User who created the subscription', example: 'user1', required: false })
+  @ApiProperty({
+    description: 'User who created the subscription',
+    example: 'user1',
+    required: false,
+  })
   @IsString()
   @IsOptional()
   createBy?: string;
 
-  @ApiProperty({ description: 'Last updated date of the subscription', example: '2023-07-12T00:00:00.000Z', required: false })
+  @ApiProperty({
+    description: 'Last updated date of the subscription',
+    example: '2023-07-12T00:00:00.000Z',
+    required: false,
+  })
   @IsISO8601()
   @IsOptional()
   updatedAt?: Date | null;
 
-  @ApiProperty({ description: 'User who last updated the subscription', example: 'user2', required: false })
+  @ApiProperty({
+    description: 'User who last updated the subscription',
+    example: 'user2',
+    required: false,
+  })
   @IsString()
   @IsOptional()
   updateBy?: string;
 
-  @ApiProperty({ description: 'Deletion date of the subscription', example: '2023-07-13T00:00:00.000Z', required: false })
+  @ApiProperty({
+    description: 'Deletion date of the subscription',
+    example: '2023-07-13T00:00:00.000Z',
+    required: false,
+  })
   @IsISO8601()
   @IsOptional()
   deletedAt?: Date | null;
 
-  @ApiProperty({ description: 'User who deleted the subscription', example: 'user3', required: false })
+  @ApiProperty({
+    description: 'User who deleted the subscription',
+    example: 'user3',
+    required: false,
+  })
   @IsString()
   @IsOptional()
   deleteBy?: string;
 }
-

--- a/src/libs/apiKeySubs/dtos/update-apy-key-subs.dto.ts
+++ b/src/libs/apiKeySubs/dtos/update-apy-key-subs.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty, PartialType } from '@nestjs/swagger';
+import { IsString, IsOptional, IsInt, IsBoolean, IsDate, IsISO8601 } from 'class-validator';
+import { CreateApiKeySubscriptionDto } from './create-apy-key-subs.dto'
+
+export class UpdateApiKeySubscriptionDto extends PartialType(CreateApiKeySubscriptionDto) {
+  @ApiProperty({ description: 'Type of the API key subscription', example: 'basic', required: false })
+  @IsString()
+  @IsOptional()
+  type?: string;
+
+  @ApiProperty({ description: 'API key for the subscription', example: 'abc123', required: false })
+  @IsString()
+  @IsOptional()
+  apiKey?: string;
+
+  @ApiProperty({ description: 'Usage count of the API key subscription', example: 0, required: false })
+  @IsInt()
+  @IsOptional()
+  usageCount?: number;
+
+  @ApiProperty({ description: 'Usage limit for the API key subscription', example: 100, required: false })
+  @IsInt()
+  @IsOptional()
+  limit?: number;
+
+  @ApiProperty({ description: 'Status of the API key subscription', example: true, required: false })
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+
+  @ApiProperty({ description: 'Creation date of the subscription', example: '2023-07-11T00:00:00.000Z', required: false })
+  @IsISO8601()
+  @IsOptional()
+  createdAt?: Date | null;
+
+  @ApiProperty({ description: 'User who created the subscription', example: 'user1', required: false })
+  @IsString()
+  @IsOptional()
+  createBy?: string;
+
+  @ApiProperty({ description: 'Last updated date of the subscription', example: '2023-07-12T00:00:00.000Z', required: false })
+  @IsISO8601()
+  @IsOptional()
+  updatedAt?: Date | null;
+
+  @ApiProperty({ description: 'User who last updated the subscription', example: 'user2', required: false })
+  @IsString()
+  @IsOptional()
+  updateBy?: string;
+
+  @ApiProperty({ description: 'Deletion date of the subscription', example: '2023-07-13T00:00:00.000Z', required: false })
+  @IsISO8601()
+  @IsOptional()
+  deletedAt?: Date | null;
+
+  @ApiProperty({ description: 'User who deleted the subscription', example: 'user3', required: false })
+  @IsString()
+  @IsOptional()
+  deleteBy?: string;
+}
+

--- a/src/libs/apiKeySubs/entities/apiKeySubs.entity.ts
+++ b/src/libs/apiKeySubs/entities/apiKeySubs.entity.ts
@@ -39,4 +39,5 @@ export class ApiKeySubscription {
   deleteBy: string;
 }
 
-export const ApiKeySubscriptionSchema = SchemaFactory.createForClass(ApiKeySubscription);
+export const ApiKeySubscriptionSchema =
+  SchemaFactory.createForClass(ApiKeySubscription);

--- a/src/libs/apiKeySubs/entities/apiKeySubs.entity.ts
+++ b/src/libs/apiKeySubs/entities/apiKeySubs.entity.ts
@@ -1,0 +1,42 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+export type ApiKeySubscriptionDocument = ApiKeySubscription & Document;
+
+@Schema()
+export class ApiKeySubscription {
+  @Prop({ required: true })
+  type: string;
+
+  @Prop({ required: true })
+  apiKey: string;
+
+  @Prop({ default: 0 })
+  usageCount: number;
+
+  @Prop({ required: true })
+  limit: number;
+
+  @Prop({ default: true })
+  isActive: boolean;
+
+  @Prop({ default: null })
+  createdAt: Date | null;
+
+  @Prop()
+  createBy: string;
+
+  @Prop({ default: null })
+  updatedAt: Date | null;
+
+  @Prop()
+  updateBy: string;
+
+  @Prop({ default: null })
+  deletedAt: Date | null;
+
+  @Prop()
+  deleteBy: string;
+}
+
+export const ApiKeySubscriptionSchema = SchemaFactory.createForClass(ApiKeySubscription);


### PR DESCRIPTION
- Add `ApiKeySubscription` entity with properties: type, apiKey, usageCount, limit, isActive, createdAt, createBy, updatedAt, updateBy, deletedAt, and deleteBy.
- Create `CreateApiKeySubscriptionDto` with necessary validation and Swagger annotations.
- Create `UpdateApiKeySubscriptionDto` using `PartialType` to allow partial updates, with appropriate validation and Swagger annotations.
