### PR TITLE
Unit test for generateApiKey tested 2 of 2

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,7 +8,6 @@ import { ApiKeyModule } from './libs/auth/api-key.module';
 import { ApiKeySubscriptionModule } from './libs/apiKeySubs/apikeyUser.module';
 import { LogsModule } from './modules/logs/logs.module';
 
-
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -21,11 +20,11 @@ import { LogsModule } from './modules/logs/logs.module';
     LogsModule,
     PersistenceModule,
   ],
-   providers: [
+  providers: [
     {
       provide: APP_GUARD,
       useClass: AuthGuard,
     },
-  ], 
+  ],
 })
 export class AppModule {}

--- a/src/libs/apiKeySubs/service/apiKeySubs.service.ts
+++ b/src/libs/apiKeySubs/service/apiKeySubs.service.ts
@@ -20,7 +20,7 @@ export class ApiKeySubscriptionService {
     private apiKeySubscriptionModel: Model<ApiKeySubscriptionDocument>,
   ) {}
 
-  private async generateApiKey(type: string): Promise<string> {
+  async generateApiKey(type: string): Promise<string> {
     try {
       const length = type === 'tvs' ? 6 : 20;
       return await [...Array(length)]

--- a/src/libs/apiKeySubs/service/apikeySubs.spec.ts
+++ b/src/libs/apiKeySubs/service/apikeySubs.spec.ts
@@ -1,0 +1,46 @@
+
+import { ApiKeySubscriptionService } from './apikeySubs.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { ApiKeySubscription } from '../entities/apiKeySubs.entity';
+
+
+ describe('ApiKeySubscriptionService', () => {
+  let service: ApiKeySubscriptionService;
+  let apiKeySubscriptionModel: any;
+
+  beforeEach(async () => {
+    apiKeySubscriptionModel = {
+      save: jest.fn(),
+      findOne: jest.fn(),
+      find: jest.fn(),
+      limit: jest.fn(),
+      exec: jest.fn(),
+      findByIdAndUpdate: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApiKeySubscriptionService,
+        {
+          provide: getModelToken(ApiKeySubscription.name),
+          useValue: apiKeySubscriptionModel,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ApiKeySubscriptionService>(ApiKeySubscriptionService);
+  });
+
+  describe('generateApiKey', () => {
+    it('should generate a 6 character API key for type "tvs"', async () => {
+      const apiKey = await service['generateApiKey']('tvs');
+      expect(apiKey).toHaveLength(6);
+    });
+
+    it('should generate a 20 character API key for other types', async () => {
+      const apiKey = await service['generateApiKey']('other');
+      expect(apiKey).toHaveLength(20);
+    });
+  }); 
+});

--- a/src/libs/auth/controller/auth.controller.ts
+++ b/src/libs/auth/controller/auth.controller.ts
@@ -167,8 +167,7 @@ export class AuthController {
   @ApiParam({ name: 'id', type: 'string', description: 'API key ID' })
   @ApiResponse({
     status: 200,
-    description:
-      'API key revoked successfully.',
+    description: 'API key revoked successfully.',
   })
   @ApiInternalServerErrorResponse({ description: 'Internal server error.' })
   async remove(@Param('id') id: string) {


### PR DESCRIPTION
It was tested that API keys of type 'tvs' have exactly 6 characters and other types have 20 characters